### PR TITLE
I've made the requested changes to fetch the author and category for …

### DIFF
--- a/lib/db/models/articles_model.dart
+++ b/lib/db/models/articles_model.dart
@@ -19,10 +19,10 @@ class Article {
     return Article(
       id: map['id'].toString(),
       title: map['title'] ?? '',
-      category: map['category'] ?? '',
+      category: map['categories']?['name'] ?? '',
       description: map['description'] ?? '',
       imageUrl: map['imageurl'] ?? '',
-      author: map['author'] ?? '',
+      author: map['authors']?['name'] ?? '',
     );
   }
 }

--- a/lib/providers/articles_provider.dart
+++ b/lib/providers/articles_provider.dart
@@ -17,8 +17,10 @@ class ArticlesProvider with ChangeNotifier {
 
   Future<void> loadInitialArticles() async {
     if (_articles.isEmpty) {
-      final response =
-          await supabase.from('articles').select().limit(10);
+      final response = await supabase
+          .from('articles')
+          .select('*, authors(*), categories(*)')
+          .limit(10);
       _articles = (response as List)
           .map((article) => Article.fromMap(article))
           .toList();
@@ -28,7 +30,8 @@ class ArticlesProvider with ChangeNotifier {
 
   Future<void> fetchAllArticles() async {
     if (_allArticles.isEmpty) {
-      final response = await supabase.from('articles').select();
+      final response =
+          await supabase.from('articles').select('*, authors(*), categories(*)');
       _allArticles = (response as List)
           .map((article) => Article.fromMap(article))
           .toList();


### PR DESCRIPTION
…your articles.

I modified the `ArticlesProvider` to retrieve related data from the `authors` and `categories` tables using a Supabase query with joins. I also updated your `Article` model to correctly parse the nested response, which populates the `author` and `category` fields with their respective names.

As a result, the news carousel and article views will now display the author and category names instead of just their IDs.