### PR TITLE
fix: Correct services screen navigation and map launcher

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -41,5 +41,13 @@
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="http" />
+        </intent>
     </queries>
 </manifest>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,5 +45,11 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>https</string>
+		<string>http</string>
+		<string>comgooglemaps</string>
+	</array>
 </dict>
 </plist>

--- a/lib/app_entry.dart
+++ b/lib/app_entry.dart
@@ -23,14 +23,10 @@ class _AppEntryState extends State<AppEntry> with WidgetsBindingObserver {
   // Define the pages for the bottom navigation bar
   static const List<Widget> _widgetOptions = <Widget>[
     HomePage(),
-    DocumentPage(), // Home
-    ArticlePage(), // Resources
+    DocumentPage(), // Resources
     ServicesScreen(), // Services
-    Account(), // Leaderboard
-    // DocumentPage(),
-    // Services(),
-    // Leaderboard(),
-    // Settings(),
+    Placeholder(), // Leaderboard
+    Account(), // Account
   ];
 
   @override


### PR DESCRIPTION
- Corrected the order of the screens in the bottom navigation bar to place the services screen under the 'Services' tab.
- Fixed the map launcher issue by adding the necessary queries to `AndroidManifest.xml` and `Info.plist` to allow the app to launch map URLs.