### PR TITLE
fix: Use geo URI scheme to launch map application

### DIFF
--- a/lib/screens/services/widgets/service_list_item.dart
+++ b/lib/screens/services/widgets/service_list_item.dart
@@ -9,10 +9,10 @@ class ServiceListItem extends StatelessWidget {
 
   Future<void> _launchMaps(double? lat, double? lon) async {
     if (lat == null || lon == null) return;
-    final uri = Uri.parse('https://www.google.com/maps/search/?api=1&query=$lat,$lon');
-    if (await canLaunchUrl(uri)) {
-      await launchUrl(uri);
-    } else {
+    final uri = Uri.parse('geo:$lat,$lon');
+    try {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } catch (e) {
       throw 'Could not launch $uri';
     }
   }


### PR DESCRIPTION
- I modified the `_launchMaps` method to use the `geo:` URI scheme, which is the platform-agnostic way to represent a location.
- I set the `launchMode` to `LaunchMode.externalApplication` to ensure the map application is opened externally.
- I removed the `canLaunchUrl` check as it is no longer recommended.