### PR TITLE
feat: Implement tap-to-dial functionality for service contacts

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -53,5 +53,9 @@
             <action android:name="android.intent.action.VIEW" />
             <data android:scheme="geo" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="tel" />
+        </intent>
     </queries>
 </manifest>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -50,6 +50,7 @@
 		<string>https</string>
 		<string>http</string>
 		<string>comgooglemaps</string>
+		<string>tel</string>
 	</array>
 </dict>
 </plist>

--- a/lib/screens/services/widgets/service_list_item.dart
+++ b/lib/screens/services/widgets/service_list_item.dart
@@ -17,6 +17,15 @@ class ServiceListItem extends StatelessWidget {
     }
   }
 
+  Future<void> _launchDialer(String phoneNumber) async {
+    final uri = Uri.parse('tel:$phoneNumber');
+    try {
+      await launchUrl(uri);
+    } catch (e) {
+      throw 'Could not launch $uri';
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Card(
@@ -31,7 +40,16 @@ class ServiceListItem extends StatelessWidget {
               children: [
                 if (service.location != null) Text('Location: ${service.location}'),
                 if (service.contacts != null && service.contacts!.isNotEmpty)
-                  Text('Contacts: ${service.contacts!.join(", ")}'),
+                  Wrap(
+                    spacing: 8.0,
+                    runSpacing: 4.0,
+                    children: service.contacts!
+                        .map((contact) => ActionChip(
+                              label: Text(contact),
+                              onPressed: () => _launchDialer(contact),
+                            ))
+                        .toList(),
+                  ),
                 if (service.type != null) Text('Type: ${service.type}'),
                 if (service.latitude != null && service.longitude != null)
                   IconButton(


### PR DESCRIPTION
- Updated the `ServiceListItem` to display phone numbers as tappable pill buttons.
- Implemented a method to launch the phone dialer with the selected number pre-filled using the `url_launcher` package.
- Added the `tel` scheme to `AndroidManifest.xml` and `Info.plist` to allow the app to launch the dialer.