### PR TITLE
feat: Implement delete account with 30-day grace period

### DIFF
--- a/lib/auth/auth_service.dart
+++ b/lib/auth/auth_service.dart
@@ -15,6 +15,22 @@ class AuthService extends ChangeNotifier {
       email: email,
       password: password,
     );
+
+    if (res.user != null) {
+      final profile = await Supabase.instance.client
+          .from('profiles')
+          .select()
+          .eq('id', res.user!.id)
+          .single();
+
+      if (profile['marked_for_deletion_at'] != null) {
+        await Supabase.instance.client
+            .from('profiles')
+            .update({'marked_for_deletion_at': null})
+            .eq('id', res.user!.id);
+      }
+    }
+
     notifyListeners();
     return res;
   }

--- a/lib/screens/Account/AccountSettings/widgets/delete_account_dialog.dart
+++ b/lib/screens/Account/AccountSettings/widgets/delete_account_dialog.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/material.dart';
 import 'package:lottie/lottie.dart';
 import 'package:slide_to_act/slide_to_act.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:youthspot/config/constants.dart';
+import 'package:youthspot/main.dart';
 
 import '../../../../config/font_constants.dart';
 
@@ -158,6 +161,11 @@ class _DeleteAccountDialogState extends State<DeleteAccountDialog> {
             return SlideAction(
               key: _sliderKey,
               onSubmit: () async {
+                final userId = supabase.auth.currentUser?.id;
+                if (userId != null) {
+                  await supabase.functions.invoke('delete-user-soft', body: {'userId': userId});
+                }
+                await supabase.auth.signOut();
                 // Show loading inside slider
                 await Future.delayed(const Duration(seconds: 1));
                 _goToPage(2); // Go to success step


### PR DESCRIPTION
- Added a `marked_for_deletion_at` column to the `profiles` table.
- Created a `delete-user-soft` Supabase Edge Function to mark an account for deletion.
- Created a `delete-user-hard` Supabase Edge Function to permanently delete accounts after 30 days.
- Implemented the client-side logic to call the soft delete function when you delete your account.
- Implemented re-activation logic to clear the `marked_for_deletion_at` flag when you log back in within the grace period.