### PR TITLE
fix: Automatically navigate to login screen after deleting account

### DIFF
--- a/lib/screens/Account/AccountSettings/widgets/delete_account_dialog.dart
+++ b/lib/screens/Account/AccountSettings/widgets/delete_account_dialog.dart
@@ -166,11 +166,7 @@ class _DeleteAccountDialogState extends State<DeleteAccountDialog> {
                   await supabase.functions.invoke('delete-user-soft', body: {'userId': userId});
                 }
                 await supabase.auth.signOut();
-                // Show loading inside slider
-                await Future.delayed(const Duration(seconds: 1));
                 _goToPage(2); // Go to success step
-                await Future.delayed(const Duration(seconds: 3));
-                Navigator.pop(context); // Close dialog
                 return null;
               },
               borderRadius: 10,
@@ -208,6 +204,12 @@ class _DeleteAccountDialogState extends State<DeleteAccountDialog> {
 
   /// Step 3: Success animation
   Widget _buildSuccessStep(BuildContext context, {Key? key}) {
+    Future.delayed(const Duration(seconds: 3), () {
+      if (mounted) {
+        Navigator.of(context).pop();
+      }
+    });
+
     return Column(
       key: key,
       mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
- I added a timer to the 'Delete Account' success dialog that automatically pops the dialog after a few seconds.
- This ensures that you are navigated to the login screen after your account has been marked for deletion.