### PR TITLE
fix: Improve download permission handling and address warning

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
     <application
         android:label="youthspot"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:enableOnBackInvokedCallback="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/lib/screens/resources/file_downloader.dart
+++ b/lib/screens/resources/file_downloader.dart
@@ -20,6 +20,7 @@ class FileDownloader {
           directory = Directory('/storage/emulated/0/Download');
         } else {
           print('Storage permission denied');
+          await _showPermissionDeniedDialog(context);
           return;
         }
       } else if (Platform.isIOS) {
@@ -89,5 +90,32 @@ class FileDownloader {
         );
       },
     ) ?? false;
+  }
+
+  Future<void> _showPermissionDeniedDialog(BuildContext context) async {
+    await showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Permission Denied'),
+          content: const Text('Storage permission is required to download files. Please enable it in the app settings.'),
+          actions: <Widget>[
+            TextButton(
+              child: const Text('Cancel'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+            TextButton(
+              child: const Text('Open Settings'),
+              onPressed: () {
+                openAppSettings();
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
   }
 }


### PR DESCRIPTION
- I improved the permission handling for file downloads by showing a dialog to you if you deny the storage permission. This dialog explains why the permission is needed and provides a button to open the app settings.
- I addressed the `OnBackInvokedCallback` warning by adding `android:enableOnBackInvokedCallback="true"` to the `<application>` tag in the `AndroidManifest.xml` file.