### PR TITLE
fix: Use app-specific directory for downloads on Android 10+

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="29"/>
     <application
         android:label="youthspot"
         android:name="${applicationName}"

--- a/lib/screens/resources/file_downloader.dart
+++ b/lib/screens/resources/file_downloader.dart
@@ -13,16 +13,7 @@ class FileDownloader {
       print('Starting download for $fileName');
 
       if (Platform.isAndroid) {
-        print('Requesting storage permission on Android');
-        var status = await Permission.storage.request();
-        if (status.isGranted) {
-          print('Storage permission granted');
-          directory = Directory('/storage/emulated/0/Download');
-        } else {
-          print('Storage permission denied');
-          await _showPermissionDeniedDialog(context);
-          return;
-        }
+        directory = await getExternalStorageDirectory();
       } else if (Platform.isIOS) {
         print('Getting documents directory on iOS');
         directory = await getApplicationDocumentsDirectory();
@@ -98,18 +89,11 @@ class FileDownloader {
       builder: (BuildContext context) {
         return AlertDialog(
           title: const Text('Permission Denied'),
-          content: const Text('Storage permission is required to download files. Please enable it in the app settings.'),
+          content: const Text('Storage permission is required to download files. Please go to Settings > Apps > YouthSpot > Permissions and enable Storage.'),
           actions: <Widget>[
             TextButton(
-              child: const Text('Cancel'),
+              child: const Text('OK'),
               onPressed: () {
-                Navigator.of(context).pop();
-              },
-            ),
-            TextButton(
-              child: const Text('Open Settings'),
-              onPressed: () {
-                openAppSettings();
                 Navigator.of(context).pop();
               },
             ),


### PR DESCRIPTION
- Updated the `AndroidManifest.xml` to set `android:maxSdkVersion="29"` for the `WRITE_EXTERNAL_STORAGE` permission.
- Refactored the `file_downloader.dart` to use the app-specific directory for downloads on Android, which is the correct approach for Android 10 and above.