### PR TITLE
fix: Use MANAGE_EXTERNAL_STORAGE for downloads on Android 11+

### DIFF
--- a/lib/screens/resources/file_downloader.dart
+++ b/lib/screens/resources/file_downloader.dart
@@ -10,7 +10,7 @@ class FileDownloader {
   Future<void> downloadFile(BuildContext context, String url, String fileName, Function(int, int) onProgress) async {
     try {
       // Request storage permission first
-      var status = await Permission.storage.request();
+      var status = await Permission.manageExternalStorage.request();
       if (!status.isGranted) {
         print('Storage permission denied');
         await _showPermissionDeniedDialog(context);


### PR DESCRIPTION
- I updated the `AndroidManifest.xml` with the `MANAGE_EXTERNAL_STORAGE` permission and legacy storage attributes.
- I refactored `file_downloader.dart` to request `Permission.manageExternalStorage` on Android.