### PR TITLE
Fix: Refactor EventProvider to correctly add events to calendar

### DIFF
--- a/lib/providers/event_provider.dart
+++ b/lib/providers/event_provider.dart
@@ -32,30 +32,31 @@ class EventProvider extends ChangeNotifier {
   }
 
   Future<void> addEvent(Event event) async {
-    // Add event to the local list
-    _events.add(event);
+    final newEvent = await SSIDatabase.instance.createEvent(event);
+    _events = [..._events, newEvent];
     notifyListeners();
-
-    // Save the event to the database
-    await SSIDatabase.instance.createEvent(event);
   }
 
   Future<void> deleteEvent(Event event) async {
-    // Remove the event from the local list
-    _events.remove(event);
-    notifyListeners();
-
     // Delete the event from the database
     await SSIDatabase.instance.deleteEvent(event.notificationId!);
+
+    _events = _events
+        .where((e) => e.notificationId != event.notificationId)
+        .toList();
+    notifyListeners();
   }
 
   Future<void> editEvent(Event newEvent, Event oldEvent) async {
-    final index = _events.indexOf(oldEvent);
-    _events[index] = newEvent;
-    notifyListeners();
-
     // Update the event in the database
     await SSIDatabase.instance.updateEvent(newEvent);
+
+    final index = _events.indexOf(oldEvent);
+    if (index != -1) {
+      _events = List.from(_events);
+      _events[index] = newEvent;
+      notifyListeners();
+    }
   }
 
    int getActiveEventCount() {


### PR DESCRIPTION
The previous implementation of the EventProvider mutated the list of events directly. This prevented the UI from updating because the list's object reference did not change, and thus the Provider package did not detect a state change.

This commit refactors the addEvent, deleteEvent, and editEvent methods in the EventProvider to use immutable patterns. Instead of modifying the existing list, these methods now create a new list for each state update. This ensures that the Provider correctly detects changes and notifies listeners, causing the UI to rebuild with the updated event data.

Additionally, the addEvent method now waits for the event to be saved to the database to retrieve its ID before adding it to the state. This fixes a bug where newly created events had a null ID in the app's state, which would cause issues when editing or deleting them.