### PR TITLE
I've fixed the login redirection issue.

### DIFF
--- a/lib/auth/auth_layout.dart
+++ b/lib/auth/auth_layout.dart
@@ -16,7 +16,7 @@ class AuthLayout extends StatelessWidget {
 
    @override
   Widget build(BuildContext context) {
-    final auth = Provider.of<AuthService>(context, listen: true);
+    final auth = Provider.of<AuthService>(context, listen: false);
 
     return StreamBuilder(
       stream: auth.authStateChanges,

--- a/lib/auth/auth_service.dart
+++ b/lib/auth/auth_service.dart
@@ -31,7 +31,6 @@ class AuthService extends ChangeNotifier {
       }
     }
 
-    notifyListeners();
     return res;
   }
 
@@ -56,13 +55,11 @@ class AuthService extends ChangeNotifier {
         'mobile_number': mobileNumber,
       });
     }
-    notifyListeners();
     return res;
   }
 
   Future<void> signOut() async {
     await supabaseAuth.signOut();
-    notifyListeners();
   }
 
   Future<void> resetPassword({required String email}) async {
@@ -71,7 +68,6 @@ class AuthService extends ChangeNotifier {
 
   Future<void> updateUsername({required String username}) async {
     await supabaseAuth.updateUser(UserAttributes(data: {'username': username}));
-    notifyListeners();
   }
 
   Future<void> deleteAccount({
@@ -80,7 +76,6 @@ class AuthService extends ChangeNotifier {
   }) async {
     await Supabase.instance.client.rpc('delete_user');
     await supabaseAuth.signOut();
-    notifyListeners();
   }
 
   Future<void> reauthenticateUser({required String currentPassword}) async {
@@ -96,6 +91,5 @@ class AuthService extends ChangeNotifier {
 
   Future<void> updatePassword({required String newPassword}) async {
     await supabaseAuth.updateUser(UserAttributes(password: newPassword));
-    notifyListeners();
   }
 }


### PR DESCRIPTION
The app wasn't redirecting to the home screen after you logged in because of a race condition between two state management patterns: `ChangeNotifier` and `StreamBuilder`.

The `AuthService` was using `notifyListeners()` to signal state changes, while the `AuthLayout` was using a `StreamBuilder` to listen for authentication updates from Supabase. This created a race condition where the UI would rebuild before the auth stream emitted the new state, leaving you on the login screen.

I've resolved the issue by:

1.  Removing the redundant `notifyListeners()` calls from `AuthService`.
2.  Updating `AuthLayout` to use `Provider.of<AuthService>(context, listen: false)`, making the `StreamBuilder` the single source of truth for authentication state.